### PR TITLE
Add versioned DI weighting profiles by business context (DRRA-048)

### DIFF
--- a/backend/services/defensibility.py
+++ b/backend/services/defensibility.py
@@ -146,6 +146,10 @@ class DefensibilityResult:
     false_positive_rate: float
     recovery_fidelity: float
     sample_size: int
+    # Which business-context weighting produced this score (DRRA-048). Two DI
+    # scores are only directly comparable when these match — see di_profiles.
+    profile_id: str = "balanced"
+    profile_version: str = "1.0.0"
 
     def as_dict(self) -> Dict:
         return {
@@ -153,6 +157,7 @@ class DefensibilityResult:
             "score_0_100": self.score_0_100,
             "components": self.components.as_dict(),
             "weights": {k: round(v, 4) for k, v in self.weights.items()},
+            "profile": {"id": self.profile_id, "version": self.profile_version},
             "metrics": {
                 "mttd_seconds": round(self.mttd_seconds, 3),
                 "mttc_seconds": round(self.mttc_seconds, 3),
@@ -173,12 +178,33 @@ class DefensibilityIndex:
         mttc_sla_seconds: Optional[float] = None,
         detection_deadline_seconds: Optional[float] = None,
         fpr_penalty: bool = False,
+        profile_id: str = "balanced",
+        profile_version: str = "1.0.0",
     ) -> None:
         cfg_weights, cfg_sla, cfg_deadline = _load_config()
         self.weights = self._normalize_weights(weights or cfg_weights)
         self.mttc_sla = float(mttc_sla_seconds or cfg_sla)
         self.detection_deadline = float(detection_deadline_seconds or cfg_deadline)
         self.fpr_penalty = fpr_penalty
+        # Business-context weighting identity carried onto every result (DRRA-048).
+        self.profile_id = profile_id
+        self.profile_version = profile_version
+
+    @classmethod
+    def from_profile(cls, profile_id: str, version: Optional[str] = None, **kwargs) -> "DefensibilityIndex":
+        """Build a DI configured with a named, versioned weighting profile
+        (DRRA-048). The resulting scores are tagged with the profile identity so
+        they are only compared within the same profile+version.
+        """
+        from services.di_profiles import get_profile
+
+        profile = get_profile(profile_id, version)
+        return cls(
+            weights=dict(profile.weights),
+            profile_id=profile.profile_id,
+            profile_version=profile.version,
+            **kwargs,
+        )
 
     # -- component normalisation ---------------------------------------------
     @staticmethod
@@ -254,6 +280,8 @@ class DefensibilityIndex:
             false_positive_rate=false_positive_rate,
             recovery_fidelity=recovery_fidelity,
             sample_size=sample_size,
+            profile_id=self.profile_id,
+            profile_version=self.profile_version,
         )
 
     # -- aggregation over many incidents -------------------------------------

--- a/backend/services/di_profiles.py
+++ b/backend/services/di_profiles.py
@@ -1,0 +1,128 @@
+"""
+DRRA-048 — Versioned Defensibility Index weighting profiles by business context.
+
+The Defensibility Index (backend/services/defensibility.py) combines four
+component scores with a set of weights. Different organizations legitimately
+weight resilience differently: a data-centric business cares most about
+recoverability, a high-velocity environment about fast detection/containment, a
+regulated one about immutability. This module provides *named, versioned*
+weighting profiles so a deployment can select a business-appropriate weighting
+without editing code or forking the metric.
+
+Comparability guarantee (the reason profiles are versioned)
+-----------------------------------------------------------
+The DI remains a weighted harmonic mean of the SAME four component definitions
+on the SAME [0, 1] scale regardless of profile — only the weights differ. That
+means two DI scores are directly comparable **only when they were produced by
+the same (profile_id, profile_version)**. Every profile therefore carries an
+immutable id + semantic version, and a computed score records which profile
+produced it (see DefensibilityResult.profile_id / profile_version). Changing a
+profile's weights is a version bump, never an in-place edit, so historical
+scores stay attributable to the exact weighting that produced them.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Dict, List
+
+# The four canonical component keys the DI expects.
+_COMPONENTS = ("detection", "containment", "prevention", "recovery")
+
+
+@dataclass(frozen=True)
+class WeightingProfile:
+    """An immutable, versioned set of DI component weights for a business context."""
+
+    profile_id: str
+    version: str
+    description: str
+    weights: Dict[str, float]
+
+    def __post_init__(self) -> None:
+        keys = set(self.weights)
+        if keys != set(_COMPONENTS):
+            raise ValueError(
+                f"profile {self.profile_id!r} must weight exactly {_COMPONENTS}, got {sorted(keys)}"
+            )
+        if any(w < 0 for w in self.weights.values()):
+            raise ValueError(f"profile {self.profile_id!r} has a negative weight")
+        if not math.isclose(sum(self.weights.values()), 1.0, abs_tol=1e-6):
+            raise ValueError(
+                f"profile {self.profile_id!r} weights must sum to 1.0 (got {sum(self.weights.values())})"
+            )
+
+    @property
+    def key(self) -> str:
+        return f"{self.profile_id}@{self.version}"
+
+
+# Registry of built-in profiles. Each is a distinct business posture; the weights
+# sum to 1.0 and cover exactly the four components so the DI scale is preserved.
+_PROFILES: Dict[str, WeightingProfile] = {
+    p.profile_id: p
+    for p in [
+        WeightingProfile(
+            "balanced", "1.0.0",
+            "Paper default. Even emphasis across detect / contain / prevent / recover.",
+            {"detection": 0.30, "containment": 0.30, "prevention": 0.25, "recovery": 0.15},
+        ),
+        WeightingProfile(
+            "detection_critical", "1.0.0",
+            "High-velocity environments: weight fast detection and containment.",
+            {"detection": 0.40, "containment": 0.35, "prevention": 0.15, "recovery": 0.10},
+        ),
+        WeightingProfile(
+            "recovery_critical", "1.0.0",
+            "Data-centric business: recoverability dominates.",
+            {"detection": 0.20, "containment": 0.20, "prevention": 0.20, "recovery": 0.40},
+        ),
+        WeightingProfile(
+            "prevention_critical", "1.0.0",
+            "Segmented / least-privilege estates: weight blocking attack-path completion.",
+            {"detection": 0.25, "containment": 0.30, "prevention": 0.35, "recovery": 0.10},
+        ),
+        WeightingProfile(
+            "regulated_data", "1.0.0",
+            "Compliance-driven: weight immutability / recovery fidelity.",
+            {"detection": 0.20, "containment": 0.25, "prevention": 0.20, "recovery": 0.35},
+        ),
+    ]
+}
+
+DEFAULT_PROFILE_ID = "balanced"
+
+
+def list_profiles() -> List[WeightingProfile]:
+    """Return all registered profiles (stable order by id)."""
+    return [_PROFILES[k] for k in sorted(_PROFILES)]
+
+
+def get_profile(profile_id: str, version: str | None = None) -> WeightingProfile:
+    """Look up a profile by id (and optionally assert an expected version).
+
+    Raises KeyError for an unknown id and ValueError on a version mismatch, so a
+    caller cannot silently score against a different weighting than intended.
+    """
+    if profile_id not in _PROFILES:
+        raise KeyError(
+            f"unknown DI weighting profile {profile_id!r}; known: {sorted(_PROFILES)}"
+        )
+    profile = _PROFILES[profile_id]
+    if version is not None and version != profile.version:
+        raise ValueError(
+            f"profile {profile_id!r} is version {profile.version}, not requested {version!r}"
+        )
+    return profile
+
+
+def active_profile_id() -> str:
+    """The profile a deployment selects via the ``DI_PROFILE`` env var.
+
+    Falls back to the balanced (paper) profile when unset or unknown, so a
+    misconfiguration degrades to the documented default rather than an error.
+    """
+    pid = os.getenv("DI_PROFILE", DEFAULT_PROFILE_ID)
+    return pid if pid in _PROFILES else DEFAULT_PROFILE_ID

--- a/docs/CLAIM_TRACEABILITY.md
+++ b/docs/CLAIM_TRACEABILITY.md
@@ -39,6 +39,7 @@ as such wherever reported · **Future** = not yet built.
 | Full-stack vuln scanning (frontend npm, container image, OS, pinned actions) | Future | The frontend lockfile's transitive CVEs are reported (SARIF) but not yet blocking; stronger gate = `npm audit`, a scan of the built image, a resolved `pip-audit` lockfile, and pinning third-party Actions by commit SHA (DRRA finding 9 follow-up) |
 | Detection-quality SLO enforced as a CI gate | Implemented | `.github/workflows/ci-cd.yml` detection-quality-gate + `scripts/run_fpr_eval.py` (DRRA-086): FPR budget + recall floor |
 | Claim-integrity enforced (every Implemented row's evidence exists) | Implemented | `scripts/check_claim_integrity.py` (DRRA-087); runs as a CI gate |
+| DI weighting profiles by business context (versioned, comparability-preserving) | Implemented | `backend/services/di_profiles.py`, `backend/services/defensibility.py` (`from_profile`), `tests/test_di_profiles.py` (DRRA-048): named, semantically-versioned weight sets (balanced / detection-critical / recovery-critical / prevention-critical / regulated-data) selectable via `DI_PROFILE`; the DI keeps the same component definitions and [0,1] scale under every profile and each score is tagged with its `(profile_id, version)` so scores are only compared within a profile. Wiring runtime profile selection into the dashboard endpoint is a separate step |
 
 ## Rule
 No performance number may be stated as measured unless its row above is

--- a/tests/test_di_profiles.py
+++ b/tests/test_di_profiles.py
@@ -1,0 +1,137 @@
+"""
+DRRA-048 — Versioned DI weighting profiles by business context.
+
+Verifies the profile registry (well-formedness, versioning, lookup) and that
+selecting a profile changes the weighting while preserving the DI scale and
+attaching a comparability tag to the result.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import pytest
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for p in (_REPO, os.path.join(_REPO, "backend")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from services.di_profiles import (  # noqa: E402
+    DEFAULT_PROFILE_ID,
+    WeightingProfile,
+    active_profile_id,
+    get_profile,
+    list_profiles,
+)
+from services.defensibility import DefensibilityIndex, DEFAULT_WEIGHTS  # noqa: E402
+
+
+# --- registry integrity -----------------------------------------------------
+
+def test_every_profile_is_wellformed():
+    profiles = list_profiles()
+    assert profiles, "no profiles registered"
+    for p in profiles:
+        assert set(p.weights) == {"detection", "containment", "prevention", "recovery"}
+        assert math.isclose(sum(p.weights.values()), 1.0, abs_tol=1e-6)
+        assert all(w >= 0 for w in p.weights.values())
+        assert p.version  # semantic version present
+        assert p.key == f"{p.profile_id}@{p.version}"
+
+
+def test_default_profile_matches_paper_weights():
+    p = get_profile(DEFAULT_PROFILE_ID)
+    assert p.weights == DEFAULT_WEIGHTS
+
+
+def test_malformed_profile_is_rejected():
+    with pytest.raises(ValueError):
+        WeightingProfile("bad", "1.0.0", "weights don't sum to 1",
+                         {"detection": 0.5, "containment": 0.2,
+                          "prevention": 0.2, "recovery": 0.2})
+    with pytest.raises(ValueError):
+        WeightingProfile("bad2", "1.0.0", "missing a component",
+                         {"detection": 0.5, "containment": 0.5})
+
+
+def test_unknown_profile_raises():
+    with pytest.raises(KeyError):
+        get_profile("does-not-exist")
+
+
+def test_version_mismatch_raises():
+    known = list_profiles()[0]
+    with pytest.raises(ValueError):
+        get_profile(known.profile_id, version="9.9.9")
+
+
+# --- effect on scoring ------------------------------------------------------
+
+def _score_with(profile_id):
+    di = DefensibilityIndex.from_profile(profile_id)
+    return di.score(
+        mttd_seconds=30.0, mttc_seconds=30.0, apcr=0.2,
+        recovery_fidelity=0.9, false_positive_rate=0.05, sample_size=10,
+    )
+
+
+def test_profile_is_recorded_on_result():
+    res = _score_with("recovery_critical")
+    assert res.profile_id == "recovery_critical"
+    assert res.profile_version == "1.0.0"
+    assert res.as_dict()["profile"] == {"id": "recovery_critical", "version": "1.0.0"}
+
+
+def test_from_profile_uses_profile_weights():
+    di = DefensibilityIndex.from_profile("detection_critical")
+    assert math.isclose(di.weights["detection"], 0.40, abs_tol=1e-9)
+    assert math.isclose(di.weights["recovery"], 0.10, abs_tol=1e-9)
+
+
+def test_different_profiles_change_di_but_stay_in_unit_interval():
+    # Same measured incident, different business weightings.
+    balanced = _score_with("balanced")
+    recovery = _score_with("recovery_critical")
+    detection = _score_with("detection_critical")
+    for r in (balanced, recovery, detection):
+        assert 0.0 <= r.defensibility_index <= 1.0
+        assert 0 <= r.score_0_100 <= 100
+    # Components are identical across profiles (only weights differ) — this is
+    # what keeps the metric comparable in principle across profiles.
+    assert balanced.components.as_dict() == recovery.components.as_dict()
+    # Weighting recovery (the strong component here, 0.9) more should not lower
+    # the index relative to balanced.
+    assert recovery.defensibility_index >= balanced.defensibility_index
+
+
+def test_weakest_component_still_dominates_under_any_profile():
+    # A catastrophic prevention failure (apcr=1.0 -> prevention ~ 0) must
+    # collapse the index regardless of how little weight prevention carries.
+    for pid in ("balanced", "detection_critical", "recovery_critical"):
+        di = DefensibilityIndex.from_profile(pid)
+        res = di.score(mttd_seconds=1.0, mttc_seconds=1.0, apcr=1.0,
+                       recovery_fidelity=1.0, false_positive_rate=0.0)
+        assert res.defensibility_index < 0.1, pid
+
+
+def test_active_profile_id_selection(monkeypatch):
+    monkeypatch.delenv("DI_PROFILE", raising=False)
+    assert active_profile_id() == DEFAULT_PROFILE_ID
+    monkeypatch.setenv("DI_PROFILE", "recovery_critical")
+    assert active_profile_id() == "recovery_critical"
+    # An unknown value degrades to the documented default, not an error.
+    monkeypatch.setenv("DI_PROFILE", "nonsense")
+    assert active_profile_id() == DEFAULT_PROFILE_ID
+
+
+def test_default_constructor_is_unchanged_and_tagged_balanced():
+    # Back-compat: constructing DI without a profile still works and reports the
+    # balanced identity, so existing callers keep the paper weighting.
+    di = DefensibilityIndex()
+    res = di.score(mttd_seconds=30.0, mttc_seconds=30.0, apcr=0.2,
+                   recovery_fidelity=0.9)
+    assert res.profile_id == "balanced"
+    assert res.profile_version == "1.0.0"


### PR DESCRIPTION
## Summary

Lets a deployment weight the Defensibility Index for its business context without editing code or forking the metric. Additive and backward compatible.

- **`backend/services/di_profiles.py`** — a registry of named, semantically-versioned weighting profiles: `balanced` (paper default), `detection_critical`, `recovery_critical`, `prevention_critical`, `regulated_data`. Each is validated to cover exactly the four DI components and sum to 1.0. `DI_PROFILE` selects the active profile, degrading to `balanced` on an unknown value.
- **`backend/services/defensibility.py`** — `DefensibilityIndex.from_profile()` builds a DI from a named profile; every `DefensibilityResult` now carries its `(profile_id, profile_version)`.

## Comparability (why profiles are versioned)
The DI keeps the **same component definitions and [0,1] scale under every profile** — only the weights differ. So two DI scores are directly comparable **only when their `(profile_id, version)` match**. Versioning makes that explicit and keeps historical scores attributable to the exact weighting that produced them. A profile's weights are never edited in place — a change is a version bump.

## Backward compatibility
The default `DefensibilityIndex()` constructor still uses the paper weights and is tagged `balanced@1.0.0`, so every existing caller is unchanged. Wiring runtime profile selection into the dashboard endpoint is left as a separate step (noted honestly in the traceability matrix).

## Verification
- flake8 (E9/F-series): clean
- Evidence-path gate: 0 violations
- Full test suite: **128 passed** (12 new + existing), no regressions; existing DI robustness/monotonicity tests (DRRA-082) still green

Part of #11 (Wave 2 epic). Closes #47.