### PR TITLE
Add trustworthy-time module: monotonic timestamps + clock-skew checks (DRRA-008)

### DIFF
--- a/backend/utils/trusted_time.py
+++ b/backend/utils/trusted_time.py
@@ -1,0 +1,166 @@
+"""
+DRRA-008 — Trustworthy time and clock-synchronization checks.
+
+Detection, containment, and recovery decisions are only defensible if their
+timestamps are trustworthy and correctly ordered. Two failure modes matter:
+
+  1. **Wall-clock jumps.** NTP corrections, VM pauses, and manual clock changes
+     can make the system wall clock move backward, which would let a later event
+     carry an earlier timestamp and corrupt incident ordering (and any
+     hash-chained audit built on it — DRRA-007).
+  2. **Cross-host skew.** An endpoint's clock can differ from the control
+     plane's. When an event carries a source timestamp (`occurred_at`) and the
+     receiver stamps arrival (`ingested_at`), a large skew means the source time
+     cannot be trusted at face value.
+
+This module provides:
+  * ``monotonic_timestamp()`` — a strictly non-decreasing wall-clock timestamp,
+    so event ordering is stable even if the wall clock jumps backward.
+  * ``TrustedClock`` — the same behavior with injectable time sources (so it is
+    testable and can be driven by a replay harness).
+  * ``assess_skew()`` — classify source-vs-receiver skew as ok / warn / reject
+    against configurable thresholds.
+  * ``stamp()`` — a ready-to-attach event time record (RFC 3339 wall time, a
+    monotonic sequence value, and the skew posture for a given source time).
+
+It has no external dependencies and does not import the app, so watchers,
+scripts, and the backend can all share one time vocabulary.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+# Default skew thresholds (seconds). A deployment tightens these once NTP is
+# guaranteed; the defaults are deliberately generous so ordinary drift is "ok".
+DEFAULT_SKEW_WARN_SECONDS = 5.0
+DEFAULT_SKEW_REJECT_SECONDS = 300.0  # 5 min: beyond this the source time is untrusted
+
+
+def rfc3339(ts: float) -> str:
+    """Format a POSIX timestamp as an RFC 3339 UTC string (matches the watcher)."""
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+class TrustedClock:
+    """Emits strictly non-decreasing timestamps despite wall-clock regressions.
+
+    ``wall`` returns POSIX seconds (default ``time.time``); ``mono`` returns a
+    monotonic reference (default ``time.monotonic``). The returned timestamp
+    tracks the wall clock when it advances normally, but never goes backward:
+    if the wall clock regresses, the monotonic reference is used to carry the
+    sequence forward by the elapsed real time.
+    """
+
+    def __init__(
+        self,
+        wall: Optional[Callable[[], float]] = None,
+        mono: Optional[Callable[[], float]] = None,
+    ) -> None:
+        self._wall = wall or time.time
+        self._mono = mono or time.monotonic
+        self._lock = threading.Lock()
+        self._last_ts: Optional[float] = None
+        self._last_mono: Optional[float] = None
+
+    def timestamp(self) -> float:
+        with self._lock:
+            wall = self._wall()
+            mono = self._mono()
+            if self._last_ts is None:
+                ts = wall
+            else:
+                # Candidate from the wall clock, and a floor derived from real
+                # elapsed time so we never emit a value below the last one.
+                elapsed = max(0.0, mono - self._last_mono)
+                floor = self._last_ts + elapsed
+                ts = wall if wall >= floor else floor
+                # Guarantee strict monotonicity even if both agree exactly.
+                if ts <= self._last_ts:
+                    ts = self._last_ts + 1e-6
+            self._last_ts = ts
+            self._last_mono = mono
+            return ts
+
+    def now_rfc3339(self) -> str:
+        return rfc3339(self.timestamp())
+
+
+# Process-wide default clock for callers that just want a trustworthy timestamp.
+_DEFAULT_CLOCK = TrustedClock()
+
+
+def monotonic_timestamp() -> float:
+    """A strictly non-decreasing POSIX timestamp from the process default clock."""
+    return _DEFAULT_CLOCK.timestamp()
+
+
+def monotonic_rfc3339() -> str:
+    return _DEFAULT_CLOCK.now_rfc3339()
+
+
+@dataclass
+class SkewAssessment:
+    skew_seconds: float          # source - receiver (positive => source ahead)
+    status: str                  # "ok" | "warn" | "reject"
+    warn_threshold: float
+    reject_threshold: float
+
+    @property
+    def trusted(self) -> bool:
+        return self.status != "reject"
+
+
+def assess_skew(
+    source_time: float,
+    receiver_time: float,
+    warn_seconds: float = DEFAULT_SKEW_WARN_SECONDS,
+    reject_seconds: float = DEFAULT_SKEW_REJECT_SECONDS,
+) -> SkewAssessment:
+    """Classify the skew between a source clock and the receiver clock.
+
+    ``ok`` within the warn threshold, ``warn`` between warn and reject, and
+    ``reject`` beyond the reject threshold (the source timestamp should not be
+    trusted at face value). The magnitude is symmetric — a source clock that is
+    far behind is as untrustworthy as one far ahead.
+    """
+    skew = source_time - receiver_time
+    magnitude = abs(skew)
+    if magnitude > reject_seconds:
+        status = "reject"
+    elif magnitude > warn_seconds:
+        status = "warn"
+    else:
+        status = "ok"
+    return SkewAssessment(
+        skew_seconds=skew,
+        status=status,
+        warn_threshold=warn_seconds,
+        reject_threshold=reject_seconds,
+    )
+
+
+def stamp(source_time: Optional[float] = None, clock: Optional[TrustedClock] = None) -> dict:
+    """Return an event time record.
+
+    ``wall`` is the trustworthy monotonic receiver time (RFC 3339), ``sequence``
+    is the raw monotonic value for ordering, and — when a ``source_time`` is
+    supplied — ``source`` and ``skew`` describe the source clock's posture
+    relative to the receiver.
+    """
+    clk = clock or _DEFAULT_CLOCK
+    seq = clk.timestamp()
+    record = {"wall": rfc3339(seq), "sequence": seq}
+    if source_time is not None:
+        assessment = assess_skew(source_time, seq)
+        record["source"] = rfc3339(source_time)
+        record["skew"] = {
+            "seconds": round(assessment.skew_seconds, 6),
+            "status": assessment.status,
+            "trusted": assessment.trusted,
+        }
+    return record

--- a/docs/CLAIM_TRACEABILITY.md
+++ b/docs/CLAIM_TRACEABILITY.md
@@ -39,6 +39,7 @@ as such wherever reported · **Future** = not yet built.
 | Full-stack vuln scanning (frontend npm, container image, OS, pinned actions) | Future | The frontend lockfile's transitive CVEs are reported (SARIF) but not yet blocking; stronger gate = `npm audit`, a scan of the built image, a resolved `pip-audit` lockfile, and pinning third-party Actions by commit SHA (DRRA finding 9 follow-up) |
 | Detection-quality SLO enforced as a CI gate | Implemented | `.github/workflows/ci-cd.yml` detection-quality-gate + `scripts/run_fpr_eval.py` (DRRA-086): FPR budget + recall floor |
 | Claim-integrity enforced (every Implemented row's evidence exists) | Implemented | `scripts/check_claim_integrity.py` (DRRA-087); runs as a CI gate |
+| Trustworthy time: monotonic timestamps + clock-skew checks | Implemented | `backend/utils/trusted_time.py`, `tests/test_trusted_time.py` (DRRA-008): a `TrustedClock` emits strictly non-decreasing timestamps across a backward wall-clock jump (tested with injected time sources), and `assess_skew` classifies source-vs-receiver skew as ok/warn/reject symmetrically. Dependency-free so watcher, backend, and scripts share one time vocabulary. Wiring it into the live event pipeline and enforcing NTP at deploy time are separate steps |
 
 ## Rule
 No performance number may be stated as measured unless its row above is

--- a/tests/test_trusted_time.py
+++ b/tests/test_trusted_time.py
@@ -1,0 +1,131 @@
+"""
+DRRA-008 — Trustworthy time and clock-sync checks.
+
+Verifies monotonic timestamping survives a backward wall-clock jump, and that
+cross-host skew is classified into ok / warn / reject correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+for p in (_REPO, os.path.join(_REPO, "backend")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from utils.trusted_time import (  # noqa: E402
+    TrustedClock,
+    assess_skew,
+    monotonic_timestamp,
+    rfc3339,
+    stamp,
+)
+
+
+class _FakeTime:
+    """Injectable wall/mono sources driven by a script of values."""
+
+    def __init__(self, wall_values, mono_values):
+        self._wall = list(wall_values)
+        self._mono = list(mono_values)
+
+    def wall(self):
+        return self._wall.pop(0)
+
+    def mono(self):
+        return self._mono.pop(0)
+
+
+def test_default_clock_is_strictly_increasing():
+    vals = [monotonic_timestamp() for _ in range(200)]
+    assert all(b > a for a, b in zip(vals, vals[1:])), "timestamps not strictly increasing"
+
+
+def test_backward_wall_clock_does_not_regress_timestamps():
+    # Wall clock jumps backward by 60s between the 2nd and 3rd reading, but the
+    # monotonic reference keeps advancing by 1s each step.
+    ft = _FakeTime(
+        wall_values=[1000.0, 1001.0, 941.0, 942.0],   # <- 941 is a 60s regression
+        mono_values=[500.0, 501.0, 502.0, 503.0],
+    )
+    clk = TrustedClock(wall=ft.wall, mono=ft.mono)
+    t0 = clk.timestamp()
+    t1 = clk.timestamp()
+    t2 = clk.timestamp()   # wall regressed here
+    t3 = clk.timestamp()
+    assert t0 == 1000.0
+    assert t1 == 1001.0
+    # Despite the wall going back to 941, the emitted time must not regress; it
+    # advances by the ~1s of real (monotonic) elapsed time instead.
+    assert t2 > t1
+    assert t3 > t2
+
+
+def test_forward_wall_clock_is_tracked():
+    ft = _FakeTime(
+        wall_values=[1000.0, 1005.0],
+        mono_values=[500.0, 501.0],
+    )
+    clk = TrustedClock(wall=ft.wall, mono=ft.mono)
+    assert clk.timestamp() == 1000.0
+    # A genuine 5s forward step is tracked, not clamped.
+    assert clk.timestamp() == 1005.0
+
+
+def test_equal_wall_still_advances_strictly():
+    ft = _FakeTime(
+        wall_values=[1000.0, 1000.0, 1000.0],
+        mono_values=[500.0, 500.0, 500.0],
+    )
+    clk = TrustedClock(wall=ft.wall, mono=ft.mono)
+    a, b, c = clk.timestamp(), clk.timestamp(), clk.timestamp()
+    assert a < b < c
+
+
+def test_skew_ok():
+    a = assess_skew(source_time=1000.0, receiver_time=1000.5, warn_seconds=5, reject_seconds=300)
+    assert a.status == "ok"
+    assert a.trusted is True
+
+
+def test_skew_warn():
+    a = assess_skew(source_time=1010.0, receiver_time=1000.0, warn_seconds=5, reject_seconds=300)
+    assert a.status == "warn"
+    assert a.trusted is True
+    assert round(a.skew_seconds, 3) == 10.0
+
+
+def test_skew_reject_is_symmetric():
+    ahead = assess_skew(1000.0 + 400, 1000.0, warn_seconds=5, reject_seconds=300)
+    behind = assess_skew(1000.0 - 400, 1000.0, warn_seconds=5, reject_seconds=300)
+    assert ahead.status == "reject" and not ahead.trusted
+    assert behind.status == "reject" and not behind.trusted
+
+
+def test_stamp_without_source():
+    rec = stamp()
+    assert "wall" in rec and "sequence" in rec
+    assert "source" not in rec
+    # wall is a parseable RFC 3339 string
+    from datetime import datetime
+    datetime.fromisoformat(rec["wall"])
+
+
+def test_stamp_with_trusted_source():
+    clk = TrustedClock()
+    seq = clk.timestamp()
+    rec = stamp(source_time=seq, clock=clk)
+    assert rec["source"] and rec["skew"]["status"] in ("ok", "warn")
+    assert isinstance(rec["skew"]["trusted"], bool)
+
+
+def test_rfc3339_roundtrip():
+    from datetime import datetime, timezone
+    ts = 1_700_000_000.5
+    s = rfc3339(ts)
+    parsed = datetime.fromisoformat(s)
+    assert parsed.tzinfo is not None
+    assert abs(parsed.timestamp() - ts) < 1e-3
+    assert parsed.astimezone(timezone.utc)


### PR DESCRIPTION
## Summary

Incident decisions (detection, containment, recovery) are only defensible if their timestamps are trustworthy and correctly ordered. This adds a dependency-free time utility the watcher, backend, and scripts can all share. Additive — no existing code changed.

**`backend/utils/trusted_time.py`**
- `TrustedClock` — emits strictly non-decreasing timestamps **even when the wall clock jumps backward** (NTP correction, VM pause, manual change), by carrying the sequence forward on a monotonic reference. Prevents a later event from carrying an earlier timestamp, which would corrupt incident ordering and any hash-chained audit (DRRA-007).
- `assess_skew()` — classifies source-vs-receiver clock skew as `ok` / `warn` / `reject` (symmetric magnitude) against configurable thresholds. Maps directly to the event schema's `occurred_at` (source) vs `ingested_at` (receiver).
- `stamp()` — an event time record: RFC 3339 wall time + monotonic sequence + skew posture.

## Why it matters
This underpins **DRRA-007** (tamper-evident audit) and **DRRA-059** (observability), both of which need trustworthy ordering. Wiring it into the live event pipeline and enforcing NTP at deploy time are tracked as separate steps (noted in the traceability matrix).

## Verification
- flake8 (E9/F-series): clean
- Evidence-path gate: 0 violations
- New tests (10) cover: backward-jump monotonicity with injected clocks, forward tracking, strict advance on equal wall time, symmetric skew classification, and RFC 3339 round-trip

Part of #11 (Wave 2 epic). Closes #17.