### PR TITLE
Add explainable detection outputs (DRRA-019)

### DIFF
--- a/docs/CLAIM_TRACEABILITY.md
+++ b/docs/CLAIM_TRACEABILITY.md
@@ -39,6 +39,7 @@ as such wherever reported · **Future** = not yet built.
 | Full-stack vuln scanning (frontend npm, container image, OS, pinned actions) | Future | The frontend lockfile's transitive CVEs are reported (SARIF) but not yet blocking; stronger gate = `npm audit`, a scan of the built image, a resolved `pip-audit` lockfile, and pinning third-party Actions by commit SHA (DRRA finding 9 follow-up) |
 | Detection-quality SLO enforced as a CI gate | Implemented | `.github/workflows/ci-cd.yml` detection-quality-gate + `scripts/run_fpr_eval.py` (DRRA-086): FPR budget + recall floor |
 | Claim-integrity enforced (every Implemented row's evidence exists) | Implemented | `scripts/check_claim_integrity.py` (DRRA-087); runs as a CI gate |
+| Explainable detection outputs (each alert cites contributing signals) | Implemented | `vigil/explain.py`, `tests/test_explain.py` (DRRA-019): turns a Detection + IoBVector into an analyst-facing explanation — each contributing signal cited in plain language with its observed value and share of total signal, ordered by the model's own ranking; benign and below-threshold cases produce honest summaries. A thin layer over `vigil/ml_model.py` that does not alter scoring |
 
 ## Rule
 No performance number may be stated as measured unless its row above is

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,111 @@
+"""
+DRRA-019 — Explainable detection outputs.
+
+Each alert must cite the contributing signals for the analyst. These tests build
+Detection objects directly (no training needed) so they are fast and
+deterministic, and verify the explanation layer over vigil.ml_model.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+from vigil.ml_model import FEATURES, Detection, IoBVector  # noqa: E402
+from vigil.explain import (  # noqa: E402
+    FEATURE_DESCRIPTIONS,
+    explain,
+    explain_to_text,
+)
+
+
+def _detection(score, contributing, threshold=0.85, backend="isolation_forest"):
+    return Detection(
+        anomaly_score=score,
+        is_anomaly=score >= threshold,
+        threshold=threshold,
+        contributing_features=contributing,
+        backend=backend,
+    )
+
+
+def test_every_feature_has_a_description():
+    # A new IoB feature cannot ship without an analyst-facing description.
+    assert set(FEATURE_DESCRIPTIONS) == set(FEATURES)
+
+
+def test_anomaly_cites_contributing_signals():
+    iob = IoBVector(file_rename_rate=8.0, lateral_movement_score=0.0,
+                    privilege_escalation=2.0, shadow_copy_deletion_rate=1.0)
+    det = _detection(0.93, ["file_rename_rate", "privilege_escalation", "shadow_copy_deletion_rate"])
+    exp = explain(det, iob)
+    assert exp.is_anomaly is True
+    driver_features = [d.feature for d in exp.drivers]
+    # only positive features appear, in the model's ranked order
+    assert driver_features == ["file_rename_rate", "privilege_escalation", "shadow_copy_deletion_rate"]
+    assert "lateral_movement_score" not in driver_features
+    # each driver cites a plain-language description
+    assert all(d.description for d in exp.drivers)
+    # primary driver is named in the summary
+    assert "file_rename_rate" in exp.summary
+
+
+def test_contributions_sum_to_one():
+    iob = IoBVector(file_rename_rate=3.0, lateral_movement_score=1.0,
+                    privilege_escalation=0.0, shadow_copy_deletion_rate=0.0)
+    det = _detection(0.9, ["file_rename_rate", "lateral_movement_score"])
+    exp = explain(det, iob)
+    assert abs(sum(d.contribution for d in exp.drivers) - 1.0) < 1e-9
+    ranks = [d.rank for d in exp.drivers]
+    assert ranks == [1, 2]
+
+
+def test_benign_all_zero_vector_has_no_drivers():
+    iob = IoBVector()
+    det = _detection(0.05, [])
+    exp = explain(det, iob)
+    assert exp.drivers == []
+    assert exp.is_anomaly is False
+    assert "No abnormal" in exp.summary
+
+
+def test_below_threshold_but_signals_present():
+    iob = IoBVector(privilege_escalation=1.0)
+    det = _detection(0.40, ["privilege_escalation"])
+    exp = explain(det, iob)
+    assert exp.is_anomaly is False
+    assert len(exp.drivers) == 1
+    assert "not alerting" in exp.summary
+
+
+def test_ranked_order_falls_back_to_input_order_for_unranked_positives():
+    # Model omitted a positive feature from its ranking; it should still appear,
+    # after the ranked ones, so the analyst sees every active signal.
+    iob = IoBVector(file_rename_rate=5.0, shadow_copy_deletion_rate=2.0)
+    det = _detection(0.95, ["file_rename_rate"])  # shadow omitted from ranking
+    exp = explain(det, iob)
+    features = [d.feature for d in exp.drivers]
+    assert features == ["file_rename_rate", "shadow_copy_deletion_rate"]
+
+
+def test_explain_to_text_is_human_readable():
+    iob = IoBVector(file_rename_rate=4.0, privilege_escalation=1.0)
+    det = _detection(0.9, ["file_rename_rate", "privilege_escalation"])
+    text = explain_to_text(explain(det, iob))
+    assert "file_rename_rate" in text
+    assert "% of signal" in text
+    # one summary line + one line per driver
+    assert len(text.splitlines()) == 3
+
+
+def test_as_dict_is_json_safe():
+    import json
+    iob = IoBVector(file_rename_rate=4.0)
+    det = _detection(0.9, ["file_rename_rate"])
+    d = explain(det, iob).as_dict()
+    json.dumps(d)  # must not raise
+    assert d["drivers"][0]["feature"] == "file_rename_rate"

--- a/vigil/explain.py
+++ b/vigil/explain.py
@@ -1,0 +1,133 @@
+"""
+DRRA-019 — Explainable detection outputs.
+
+The VIGIL model already ranks which Indicators-of-Behaviour drove an anomaly
+score (``Detection.contributing_features``). This module turns that ranking plus
+the raw feature vector into an analyst-facing *explanation*: each alert cites the
+contributing signals in plain language, with the observed value and its relative
+contribution, so a SOC analyst can triage without reading model internals.
+
+It is a thin, dependency-free layer over ``vigil.ml_model`` — it does not change
+scoring, so an explanation always matches the score it accompanies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from vigil.ml_model import FEATURES, Detection, IoBVector
+
+# Plain-language meaning of each IoB feature, for the analyst. Kept in lockstep
+# with FEATURES by a test so a new feature cannot ship without a description.
+FEATURE_DESCRIPTIONS = {
+    "file_rename_rate":
+        "Rapid file renames/rewrites — the core signature of bulk encryption.",
+    "lateral_movement_score":
+        "Novel SMB/remote authentication to new peers — spread across hosts.",
+    "privilege_escalation":
+        "Token impersonation / LSASS access / Kerberoast — credential theft.",
+    "shadow_copy_deletion_rate":
+        "Shadow-copy or backup deletion — recovery inhibition before encryption.",
+}
+
+
+@dataclass
+class Driver:
+    feature: str
+    description: str
+    value: float
+    contribution: float          # share of total positive signal, [0, 1]
+    rank: int                    # 1 = strongest driver
+
+
+@dataclass
+class Explanation:
+    is_anomaly: bool
+    anomaly_score: float
+    threshold: float
+    backend: str
+    summary: str
+    drivers: List[Driver] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "is_anomaly": self.is_anomaly,
+            "anomaly_score": round(self.anomaly_score, 4),
+            "threshold": self.threshold,
+            "backend": self.backend,
+            "summary": self.summary,
+            "drivers": [
+                {
+                    "feature": d.feature,
+                    "description": d.description,
+                    "value": round(d.value, 4),
+                    "contribution": round(d.contribution, 4),
+                    "rank": d.rank,
+                }
+                for d in self.drivers
+            ],
+        }
+
+
+def _ordered_features(detection: Detection, positive: List[str]) -> List[str]:
+    """Authoritative order: the model's ranked contributors first (those with a
+    positive value), then any remaining positive features by input order."""
+    ranked = [f for f in detection.contributing_features if f in positive]
+    rest = [f for f in positive if f not in ranked]
+    return ranked + rest
+
+
+def explain(detection: Detection, iob: IoBVector) -> Explanation:
+    """Build an analyst-facing explanation for a Detection over an IoBVector."""
+    values = dict(zip(FEATURES, iob.as_list()))
+    positive = [f for f in FEATURES if values.get(f, 0.0) > 0.0]
+    total = sum(values[f] for f in positive) or 1.0
+
+    ordered = _ordered_features(detection, positive)
+    drivers: List[Driver] = []
+    for rank, feature in enumerate(ordered, start=1):
+        drivers.append(
+            Driver(
+                feature=feature,
+                description=FEATURE_DESCRIPTIONS.get(feature, feature),
+                value=values[feature],
+                contribution=values[feature] / total,
+                rank=rank,
+            )
+        )
+
+    if not drivers:
+        summary = "No abnormal indicators of behaviour observed."
+    elif detection.is_anomaly:
+        top = drivers[0]
+        others = f" (+{len(drivers) - 1} more signal(s))" if len(drivers) > 1 else ""
+        summary = (
+            f"Anomaly (score {detection.anomaly_score:.2f} ≥ {detection.threshold:.2f}); "
+            f"primary driver: {top.feature}{others}."
+        )
+    else:
+        summary = (
+            f"Below threshold (score {detection.anomaly_score:.2f} < {detection.threshold:.2f}); "
+            f"{len(drivers)} indicator(s) present but not alerting."
+        )
+
+    return Explanation(
+        is_anomaly=detection.is_anomaly,
+        anomaly_score=detection.anomaly_score,
+        threshold=detection.threshold,
+        backend=detection.backend,
+        summary=summary,
+        drivers=drivers,
+    )
+
+
+def explain_to_text(explanation: Explanation) -> str:
+    """Render an explanation as a compact multi-line string for logs/alerts."""
+    lines = [explanation.summary]
+    for d in explanation.drivers:
+        lines.append(
+            f"  {d.rank}. {d.feature}={d.value:.3f} "
+            f"({d.contribution * 100:.0f}% of signal) — {d.description}"
+        )
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Each VIGIL alert now cites the contributing signals in plain language so a SOC analyst can triage without reading model internals. Additive — a thin layer over `vigil/ml_model.py` that does **not** change scoring.

**`vigil/explain.py`**
- `explain(detection, iob)` → a structured `Explanation`. Each contributing IoB signal is cited with its **observed value**, its **share of total signal**, and a **plain-language description**, ordered by the model's own `contributing_features` ranking (positive-but-unranked signals still surface, after the ranked ones, so the analyst sees every active signal).
- Benign (all-zero) and below-threshold detections produce honest summaries rather than empty output.
- `explain_to_text()` renders a compact alert body; `as_dict()` is JSON-safe for the API/dashboard.

A test keeps the per-feature descriptions in lockstep with `FEATURES`, so a new IoB feature cannot ship without an analyst-facing description.

## Verification
- flake8 (E9/F-series): clean
- Evidence-path gate: 0 violations
- New tests (8): signals cited in ranked order, contributions sum to 1, benign/below-threshold summaries, unranked-positive fallback, human-readable text, JSON-safe dict

Part of #11 (Wave 2 epic). Closes #27.